### PR TITLE
Issue 52 support assert throws

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.dakusui</groupId>
     <artifactId>thincrest</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.1.0-SNAPSHOT</version>
     <description>A thin wrapper library for hamcrest/junit to make assertion
         output descriptive.
     </description>
@@ -24,7 +24,7 @@
         <developerConnection>scm:git:git@github.com:dakusui/thincrest.git
         </developerConnection>
         <url>http://dakusui.github.io/thincrest</url>
-        <tag>thincrest-3.3.x</tag>
+        <tag>thincrest-4.1.x</tag>
     </scm>
 
     <developers>

--- a/src/main/java/com/github/dakusui/crest/Crest.java
+++ b/src/main/java/com/github/dakusui/crest/Crest.java
@@ -14,8 +14,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.github.dakusui.crest.utils.InternalUtils.composeComparisonText;
-import static com.github.dakusui.crest.utils.InternalUtils.requireArgument;
+import static com.github.dakusui.crest.utils.InternalUtils.*;
 import static com.github.dakusui.crest.utils.printable.Functions.trivial;
 import static com.github.dakusui.crest.utils.printable.Predicates.equalTo;
 import static com.github.dakusui.crest.utils.printable.Predicates.isEmptyArray;
@@ -299,7 +298,6 @@ public enum Crest {
     assumeThat("", actual, matcher);
   }
 
-
   public static <T> void requireThat(T actual, Matcher<? super T> matcher) {
     requireThat("", actual, matcher);
   }
@@ -323,6 +321,19 @@ public enum Crest {
         message, value, matcher,
         (msg, r, causes) -> new ExecutionFailure(msg, r.expectation(), r.mismatch(), causes)
     );
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
+    try {
+      executable.execute();
+    } catch (Throwable e) {
+      throwIfBlacklisted(e);
+      if (expectedType.isInstance(e))
+        return (T) e;
+      throw new AssertionFailedError("An exception of unexpected type was thrown.", expectedType, e);
+    }
+    throw new AssertionFailedError("An exception was expected to be thrown, but not.", expectedType, null);
   }
 
   public static <T, R> Function<T, R> function(String ss, Function<T, R> function) {

--- a/src/main/java/com/github/dakusui/crest/Crest.java
+++ b/src/main/java/com/github/dakusui/crest/Crest.java
@@ -243,7 +243,6 @@ public enum Crest {
     return new AsList<>(function);
   }
 
-  @SuppressWarnings("unchecked")
   public static <I extends Map<?, ?>, SELF extends AsMap<I, Object, Object, SELF>> SELF asObjectMap() {
     return asMapOf(Object.class, Object.class, trivial(function("mapToMap", HashMap::new)));
   }

--- a/src/main/java/com/github/dakusui/crest/Crest.java
+++ b/src/main/java/com/github/dakusui/crest/Crest.java
@@ -2,10 +2,11 @@ package com.github.dakusui.crest;
 
 import com.github.dakusui.crest.core.*;
 import com.github.dakusui.crest.core.Call.Arg;
+import com.github.dakusui.crest.functions.Executable;
 import com.github.dakusui.crest.matcherbuilders.*;
 import com.github.dakusui.crest.matcherbuilders.primitives.*;
-import com.github.dakusui.crest.utils.printable.Functions;
-import com.github.dakusui.crest.utils.printable.Printable;
+import com.github.dakusui.crest.functions.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Printable;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
@@ -15,9 +16,9 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.github.dakusui.crest.utils.InternalUtils.*;
-import static com.github.dakusui.crest.utils.printable.Functions.trivial;
-import static com.github.dakusui.crest.utils.printable.Predicates.equalTo;
-import static com.github.dakusui.crest.utils.printable.Predicates.isEmptyArray;
+import static com.github.dakusui.crest.functions.printable.Functions.trivial;
+import static com.github.dakusui.crest.functions.printable.Predicates.equalTo;
+import static com.github.dakusui.crest.functions.printable.Predicates.isEmptyArray;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/com/github/dakusui/crest/Executable.java
+++ b/src/main/java/com/github/dakusui/crest/Executable.java
@@ -1,0 +1,6 @@
+package com.github.dakusui.crest;
+
+@FunctionalInterface
+public interface Executable {
+  void execute() throws Throwable;
+}

--- a/src/main/java/com/github/dakusui/crest/core/Call.java
+++ b/src/main/java/com/github/dakusui/crest/core/Call.java
@@ -1,12 +1,12 @@
 package com.github.dakusui.crest.core;
 
 import com.github.dakusui.crest.utils.InternalUtils;
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 
 import java.util.Arrays;
 import java.util.function.Function;
 
-import static com.github.dakusui.crest.utils.printable.Functions.THIS;
+import static com.github.dakusui.crest.functions.printable.Functions.THIS;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/src/main/java/com/github/dakusui/crest/core/Eater.java
+++ b/src/main/java/com/github/dakusui/crest/core/Eater.java
@@ -1,6 +1,6 @@
 package com.github.dakusui.crest.core;
 
-import com.github.dakusui.crest.utils.printable.Printable;
+import com.github.dakusui.crest.functions.printable.Printable;
 import org.opentest4j.AssertionFailedError;
 
 import java.util.List;
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.github.dakusui.crest.utils.printable.Predicates.equalTo;
+import static com.github.dakusui.crest.functions.printable.Predicates.equalTo;
 import static java.util.Objects.requireNonNull;
 
 public interface Eater<T /* Target*/, C /* Target container */> {

--- a/src/main/java/com/github/dakusui/crest/core/Matcher.java
+++ b/src/main/java/com/github/dakusui/crest/core/Matcher.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static com.github.dakusui.crest.utils.InternalUtils.throwIfBlacklisted;
 import static java.util.Objects.requireNonNull;
 
 public interface Matcher<T> {
@@ -153,6 +154,7 @@ public interface Matcher<T> {
           try {
             return session.matches(this, value, exceptions::add) && exceptions.isEmpty();
           } catch (Throwable e) {
+            throwIfBlacklisted(e);
             return false;
           }
         }

--- a/src/main/java/com/github/dakusui/crest/core/MethodSelector.java
+++ b/src/main/java/com/github/dakusui/crest/core/MethodSelector.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils;
+package com.github.dakusui.crest.core;
 
 import com.github.dakusui.crest.core.Call.Arg;
 

--- a/src/main/java/com/github/dakusui/crest/core/Session.java
+++ b/src/main/java/com/github/dakusui/crest/core/Session.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.core;
 
 import com.github.dakusui.crest.functions.TransformingPredicate;
-import com.github.dakusui.crest.utils.printable.TrivialFunction;
+import com.github.dakusui.crest.functions.printable.TrivialFunction;
 import org.opentest4j.AssertionFailedError;
 
 import java.util.*;

--- a/src/main/java/com/github/dakusui/crest/core/Session.java
+++ b/src/main/java/com/github/dakusui/crest/core/Session.java
@@ -103,7 +103,7 @@ public interface Session<T> {
 
   class Impl<T> implements Session<T> {
     static class Writer {
-      private int          level  = 0;
+      private int level = 0;
       private List<String> buffer = new LinkedList<>();
 
       Impl.Writer enter() {
@@ -134,16 +134,16 @@ public interface Session<T> {
       }
     }
 
-    private static final String                              VARIABLE_NAME               = "x";
-    private static final String                              TRANSFORMED_VARIABLE_NAME   = "y";
-    private              Map<Function<?, ?>, Function<?, ?>> memoizationMapForFunctions  = new HashMap<>();
-    private              Map<Predicate<?>, Predicate<?>>     memoizationMapForPredicates = new HashMap<>();
-    private              Map<List<Object>, String>           snapshots                   = new HashMap<>();
+    private static final String VARIABLE_NAME = "x";
+    private static final String TRANSFORMED_VARIABLE_NAME = "y";
+    private Map<Function<?, ?>, Function<?, ?>> memoizationMapForFunctions = new HashMap<>();
+    private Map<Predicate<?>, Predicate<?>> memoizationMapForPredicates = new HashMap<>();
+    private Map<List<Object>, String> snapshots = new HashMap<>();
 
     Impl.Writer expectationWriter = new Impl.Writer();
-    Impl.Writer mismatchWriter    = new Impl.Writer();
+    Impl.Writer mismatchWriter = new Impl.Writer();
 
-    private boolean         result;
+    private boolean result;
     private List<Throwable> exceptions = new LinkedList<>();
 
     @Override
@@ -267,7 +267,7 @@ public interface Session<T> {
     }
 
     void endMismatch() {
-      this.mismatchWriter.leave().appendLine("]");
+      this.mismatchWriter.leave().appendLine("]: NOT MET");
     }
 
 

--- a/src/main/java/com/github/dakusui/crest/core/Session.java
+++ b/src/main/java/com/github/dakusui/crest/core/Session.java
@@ -77,6 +77,7 @@ public interface Session<T> {
               value
           ));
     } catch (RuntimeException | Error exception) {
+      throwIfBlacklisted(exception);
       listener.accept(exception);
       addException(exception);
       return false;
@@ -282,6 +283,7 @@ public interface Session<T> {
         this.apply((Function<Object, Object>) func, value);
         return false;
       } catch (Throwable t) {
+        throwIfBlacklisted(t);
         return true;
       }
     }
@@ -292,6 +294,7 @@ public interface Session<T> {
         this.test((Predicate<Object>) p, value);
         return false;
       } catch (Throwable t) {
+        throwIfBlacklisted(t);
         return true;
       }
     }
@@ -386,6 +389,7 @@ public interface Session<T> {
               O result = function.apply(j);
               return () -> result;
             } catch (RuntimeException | Error e) {
+              throwIfBlacklisted(e);
               return () -> {
                 if (e instanceof RuntimeException)
                   throw (RuntimeException) e;
@@ -404,6 +408,7 @@ public interface Session<T> {
               boolean result = predicate.test(j);
               return () -> result;
             } catch (RuntimeException | Error e) {
+              throwIfBlacklisted(e);
               return () -> {
                 if (e instanceof RuntimeException)
                   throw (RuntimeException) e;

--- a/src/main/java/com/github/dakusui/crest/functions/Executable.java
+++ b/src/main/java/com/github/dakusui/crest/functions/Executable.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest;
+package com.github.dakusui.crest.functions;
 
 @FunctionalInterface
 public interface Executable {

--- a/src/main/java/com/github/dakusui/crest/functions/printable/Functions.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/Functions.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 import com.github.dakusui.crest.utils.InternalUtils;
 

--- a/src/main/java/com/github/dakusui/crest/functions/printable/Predicates.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/Predicates.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 import com.github.dakusui.crest.utils.InternalUtils;
 

--- a/src/main/java/com/github/dakusui/crest/functions/printable/Printable.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/Printable.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 
 import java.util.function.Function;

--- a/src/main/java/com/github/dakusui/crest/functions/printable/PrintableFunction.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/PrintableFunction.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 import java.util.Objects;
 import java.util.function.Function;

--- a/src/main/java/com/github/dakusui/crest/functions/printable/PrintablePredicate.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/PrintablePredicate.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 import java.util.function.Predicate;
 

--- a/src/main/java/com/github/dakusui/crest/functions/printable/TrivialFunction.java
+++ b/src/main/java/com/github/dakusui/crest/functions/printable/TrivialFunction.java
@@ -1,4 +1,4 @@
-package com.github.dakusui.crest.utils.printable;
+package com.github.dakusui.crest.functions.printable;
 
 import java.util.function.Function;
 

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/AsComparable.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/AsComparable.java
@@ -1,6 +1,6 @@
 package com.github.dakusui.crest.matcherbuilders;
 
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.function.Function;
 

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/AsString.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/AsString.java
@@ -1,6 +1,6 @@
 package com.github.dakusui.crest.matcherbuilders;
 
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.Objects;
 import java.util.function.Function;

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/ListMatcherBuilder.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/ListMatcherBuilder.java
@@ -3,7 +3,7 @@ package com.github.dakusui.crest.matcherbuilders;
 import com.github.dakusui.crest.Crest;
 import com.github.dakusui.crest.utils.InternalUtils;
 import com.github.dakusui.crest.functions.TransformingPredicate;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/MatcherBuilder.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/MatcherBuilder.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.matcherbuilders;
 
 import com.github.dakusui.crest.core.Matcher;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/ObjectMatcherBuilder.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/ObjectMatcherBuilder.java
@@ -2,7 +2,7 @@ package com.github.dakusui.crest.matcherbuilders;
 
 import com.github.dakusui.crest.core.Matcher;
 import com.github.dakusui.crest.functions.TransformingPredicate;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.github.dakusui.crest.utils.printable.Predicates.alwaysTrue;
+import static com.github.dakusui.crest.functions.printable.Predicates.alwaysTrue;
 
 public abstract class ObjectMatcherBuilder<IN, OUT, SELF extends ObjectMatcherBuilder<IN, OUT, SELF>> implements MatcherBuilder<IN, OUT, SELF> {
   private final Function<? super IN, ? extends OUT> function;

--- a/src/main/java/com/github/dakusui/crest/matcherbuilders/primitives/AsBoolean.java
+++ b/src/main/java/com/github/dakusui/crest/matcherbuilders/primitives/AsBoolean.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.matcherbuilders.primitives;
 
 import com.github.dakusui.crest.matcherbuilders.ObjectMatcherBuilder;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 
 import java.util.function.Function;
 

--- a/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
+++ b/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
@@ -15,12 +15,13 @@ import java.util.function.Predicate;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 public enum InternalUtils {
   ;
 
-  public static final Consumer<?>     NOP                     = e -> {
+  public static final Consumer<?>  NOP                     = e -> {
   };
   public static final Class<?>[][] PRIMITIVE_WRAPPER_TABLE = {
       { boolean.class, Boolean.class },
@@ -32,6 +33,8 @@ public enum InternalUtils {
       { float.class, Float.class },
       { double.class, Double.class },
   };
+
+  private static final List<Class<? extends Error>> blacklistedErrorTypes = singletonList(OutOfMemoryError.class);
 
   /**
    * Tries to find a method whose name is {@code methodName} from a given class {@code aClass}
@@ -236,6 +239,11 @@ public enum InternalUtils {
     return klass == null
         ? null
         : klass.getSimpleName();
+  }
+
+  public static void throwIfBlacklisted(Throwable t) {
+    if (blacklistedErrorTypes.stream().anyMatch(i -> i.isInstance(t)))
+      throw (Error) t;
   }
 
   private static Class<?> toWrapperIfPrimitive(Class<?> in) {

--- a/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
+++ b/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
@@ -1,8 +1,9 @@
 package com.github.dakusui.crest.utils;
 
 import com.github.dakusui.crest.core.Call.Arg;
+import com.github.dakusui.crest.core.MethodSelector;
 import com.github.dakusui.crest.core.Report;
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.opentest4j.AssertionFailedError;
 
 import java.lang.reflect.Array;
@@ -204,7 +205,7 @@ public enum InternalUtils {
     return true;
   }
 
-  static boolean withBoxingIsAssignableFrom(Class<?> a, Class<?> b) {
+  public static boolean withBoxingIsAssignableFrom(Class<?> a, Class<?> b) {
     if (a.isAssignableFrom(b))
       return true;
     return toWrapperIfPrimitive(a).isAssignableFrom(toWrapperIfPrimitive(b));

--- a/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
+++ b/src/main/java/com/github/dakusui/crest/utils/InternalUtils.java
@@ -34,7 +34,7 @@ public enum InternalUtils {
       { double.class, Double.class },
   };
 
-  private static final List<Class<? extends Error>> blacklistedErrorTypes = singletonList(OutOfMemoryError.class);
+  private static final List<Class<? extends Error>> BLACKLISTED_ERROR_TYPES = singletonList(OutOfMemoryError.class);
 
   /**
    * Tries to find a method whose name is {@code methodName} from a given class {@code aClass}
@@ -242,7 +242,7 @@ public enum InternalUtils {
   }
 
   public static void throwIfBlacklisted(Throwable t) {
-    if (blacklistedErrorTypes.stream().anyMatch(i -> i.isInstance(t)))
+    if (BLACKLISTED_ERROR_TYPES.stream().anyMatch(i -> i.isInstance(t)))
       throw (Error) t;
   }
 

--- a/src/test/java/com/github/dakusui/crest/examples/BankAccountExample.java
+++ b/src/test/java/com/github/dakusui/crest/examples/BankAccountExample.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.examples;
 
 import com.github.dakusui.crest.utils.TestBase;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 import org.junit.Test;
 
 import java.util.stream.Stream;

--- a/src/test/java/com/github/dakusui/crest/examples/Basic.java
+++ b/src/test/java/com/github/dakusui/crest/examples/Basic.java
@@ -3,7 +3,7 @@ package com.github.dakusui.crest.examples;
 import org.junit.Test;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.*;
+import static com.github.dakusui.crest.functions.printable.Predicates.*;
 
 public class Basic {
   @Test

--- a/src/test/java/com/github/dakusui/crest/examples/InThincrest.java
+++ b/src/test/java/com/github/dakusui/crest/examples/InThincrest.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.examples;
 
 import com.github.dakusui.crest.Crest;
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.core.StringContains;
 import org.junit.Test;
@@ -9,9 +9,9 @@ import org.junit.Test;
 import java.util.*;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Functions.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.eq;
-import static com.github.dakusui.crest.utils.printable.Predicates.isEmpty;
+import static com.github.dakusui.crest.functions.printable.Functions.*;
+import static com.github.dakusui.crest.functions.printable.Predicates.eq;
+import static com.github.dakusui.crest.functions.printable.Predicates.isEmpty;
 
 /**
  * http://qiita.com/disc99/items/31fa7abb724f63602dc9

--- a/src/test/java/com/github/dakusui/crest/examples/SimpleExamples.java
+++ b/src/test/java/com/github/dakusui/crest/examples/SimpleExamples.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.examples;
 
 import com.github.dakusui.crest.Crest;
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -12,8 +12,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Functions.size;
-import static com.github.dakusui.crest.utils.printable.Predicates.eq;
+import static com.github.dakusui.crest.functions.printable.Functions.size;
+import static com.github.dakusui.crest.functions.printable.Predicates.eq;
 import static java.util.Arrays.asList;
 
 public class SimpleExamples {

--- a/src/test/java/com/github/dakusui/crest/ut/CrestFunctionsTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/CrestFunctionsTest.java
@@ -2,7 +2,7 @@ package com.github.dakusui.crest.ut;
 
 import com.github.dakusui.crest.Crest;
 import com.github.dakusui.crest.utils.TestBase;
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Functions.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.alwaysTrue;
+import static com.github.dakusui.crest.functions.printable.Functions.*;
+import static com.github.dakusui.crest.functions.printable.Predicates.alwaysTrue;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/github/dakusui/crest/ut/CrestPredicatesTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/CrestPredicatesTest.java
@@ -1,7 +1,7 @@
 package com.github.dakusui.crest.ut;
 
 import com.github.dakusui.crest.utils.TestBase;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;

--- a/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
@@ -179,7 +179,7 @@ public class CrestTest {
               + "  x->size equalTo[3]\n"
               + "  x->at[0] equalTo[\"hello\"]: NOT MET\n"
               + "    x->at[0]=\"Hello\"\n"
-              + "]",
+              + "]: NOT MET",
           description.orElseThrow(AssertionError::new).toString()
       );
     }
@@ -216,7 +216,7 @@ public class CrestTest {
                   + "  x->size failingCheck failed with java.lang.RuntimeException(FAILED)\n"
                   + "    x->size=<3>:Integer\n"
                   + "  x->at[0] equalTo[\"Hello\"]\n"
-                  + "]\n"
+                  + "]: NOT MET\n"
                   + "FAILED"
           ));
     }
@@ -253,7 +253,7 @@ public class CrestTest {
                   + "  x->failingTransform alwaysTrue failed with java.lang.RuntimeException(FAILED)\n"
                   + "    x->failingTransform=java.lang.RuntimeException(FAILED)\n"
                   + "  x->at[0] equalTo[\"Hello\"]\n"
-                  + "]\n"
+                  + "]: NOT MET\n"
                   + "FAILED"
           ));
     }
@@ -289,7 +289,7 @@ public class CrestTest {
               + "    x->size=<3>:Integer\n"
               + "  x->at[0] equalTo[\"hello\"]: NOT MET\n"
               + "    x->at[0]=\"Hello\"\n"
-              + "]",
+              + "]: NOT MET",
           description.orElseThrow(AssertionError::new).toString()
       );
     }
@@ -382,7 +382,7 @@ public class CrestTest {
               + "  x->size failingCheck failed with java.lang.RuntimeException(FAILED)\n"
               + "    x->size=<3>:Integer\n"
               + "  x->at[0] equalTo[\"Hello\"]\n"
-              + "]\n"
+              + "]: NOT MET\n"
               + "FAILED"
           )
       );
@@ -419,7 +419,7 @@ public class CrestTest {
               + "    x->size=<3>:Integer\n"
               + "  x->at[0] equalTo[\"hello\"]: NOT MET\n"
               + "    x->at[0]=\"Hello\"\n"
-              + "]",
+              + "]: NOT MET",
           description.orElseThrow(AssertionError::new).toString()
       );
     }
@@ -463,8 +463,8 @@ public class CrestTest {
               + "      x->at[0]=\"Hello\"\n"
               + "    x->at[0] equalTo[\"HELLO\"]: NOT MET\n"
               + "      x->at[0]=\"Hello\"\n"
-              + "  ]\n"
-              + "]",
+              + "  ]: NOT MET\n"
+              + "]: NOT MET",
           description.orElseThrow(AssertionError::new).toString()
       );
     }
@@ -507,8 +507,8 @@ public class CrestTest {
                   + "      x->at[0]=\"Hello\"\n"
                   + "    x->at[0] equalTo[\"HELLO\"]: NOT MET\n"
                   + "      x->at[0]=\"Hello\"\n"
-                  + "  ]\n"
-                  + "]"
+                  + "  ]: NOT MET\n"
+                  + "]: NOT MET"
           ));
     }
   }

--- a/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
@@ -3,7 +3,7 @@ package com.github.dakusui.crest.ut;
 import com.github.dakusui.crest.Crest;
 import com.github.dakusui.crest.core.*;
 import com.github.dakusui.crest.utils.TestBase;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -22,8 +22,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Functions.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.equalTo;
+import static com.github.dakusui.crest.functions.printable.Functions.*;
+import static com.github.dakusui.crest.functions.printable.Predicates.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/github/dakusui/crest/ut/EaterTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/EaterTest.java
@@ -8,7 +8,7 @@ import org.opentest4j.AssertionFailedError;
 import java.util.List;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.equalsIgnoreCase;
+import static com.github.dakusui.crest.functions.printable.Predicates.equalsIgnoreCase;
 import static java.util.Arrays.asList;
 
 public class EaterTest extends TestBase {

--- a/src/test/java/com/github/dakusui/crest/ut/Issue27Test.java
+++ b/src/test/java/com/github/dakusui/crest/ut/Issue27Test.java
@@ -13,8 +13,8 @@ import org.opentest4j.AssertionFailedError;
 import java.io.IOException;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Predicates.equalTo;
-import static com.github.dakusui.crest.utils.printable.Predicates.matchesRegex;
+import static com.github.dakusui.crest.functions.printable.Predicates.equalTo;
+import static com.github.dakusui.crest.functions.printable.Predicates.matchesRegex;
 
 public class Issue27Test extends TestBase {
   @Test

--- a/src/test/java/com/github/dakusui/crest/ut/Issue29Test.java
+++ b/src/test/java/com/github/dakusui/crest/ut/Issue29Test.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static com.github.dakusui.crest.Crest.*;
-import static com.github.dakusui.crest.utils.printable.Functions.THIS;
+import static com.github.dakusui.crest.functions.printable.Functions.THIS;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/com/github/dakusui/crest/ut/Issue52Test.java
+++ b/src/test/java/com/github/dakusui/crest/ut/Issue52Test.java
@@ -1,0 +1,31 @@
+package com.github.dakusui.crest.ut;
+
+import com.github.dakusui.crest.Crest;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opentest4j.AssertionFailedError;
+
+public class Issue52Test {
+  @Test
+  public void givenPassingAssertion$whenAssertThrows$thenPass() {
+    Assert.assertThat(
+        Crest.assertThrows(IllegalArgumentException.class, () -> {
+          throw new IllegalArgumentException();
+        }),
+        CoreMatchers.instanceOf(IllegalArgumentException.class));
+  }
+
+  @Test(expected = AssertionFailedError.class)
+  public void givenFailingAssertion() {
+    Crest.assertThrows(AssertionFailedError.class, () -> {
+      throw new IllegalArgumentException();
+    });
+  }
+
+  @Test(expected = AssertionFailedError.class)
+  public void givenFailingAssertion2() {
+    Crest.assertThrows(AssertionFailedError.class, () -> {
+    });
+  }
+}

--- a/src/test/java/com/github/dakusui/crest/ut/MatcherTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/MatcherTest.java
@@ -1,8 +1,8 @@
 package com.github.dakusui.crest.ut;
 
 import com.github.dakusui.crest.core.Matcher;
-import com.github.dakusui.crest.utils.printable.Functions;
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Predicates;
 import org.junit.Test;
 import org.opentest4j.AssertionFailedError;
 

--- a/src/test/java/com/github/dakusui/crest/ut/NotMatcherTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/NotMatcherTest.java
@@ -1,0 +1,35 @@
+package com.github.dakusui.crest.ut;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static com.github.dakusui.crest.Crest.*;
+
+@Ignore
+public class NotMatcherTest {
+  @Test
+  public void test() {
+    assertThat(
+        1,
+        not(asInteger()
+            .equalTo(1)
+            .$()));
+  }
+
+  @Test
+  public void test2() {
+    assertThat(
+        1,
+        asInteger()
+            .equalTo(2)
+            .$());
+  }
+
+  @Test
+  public void test3() {
+    assertThat(
+        1,
+        allOf(
+            asInteger().equalTo(2).$()));
+  }
+}

--- a/src/test/java/com/github/dakusui/crest/utils/ut/FunctionsTest.java
+++ b/src/test/java/com/github/dakusui/crest/utils/ut/FunctionsTest.java
@@ -1,13 +1,13 @@
 package com.github.dakusui.crest.utils.ut;
 
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
-import static com.github.dakusui.crest.utils.printable.Functions.*;
+import static com.github.dakusui.crest.functions.printable.Functions.*;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/github/dakusui/crest/utils/ut/ParameterizedFunctionsTest.java
+++ b/src/test/java/com/github/dakusui/crest/utils/ut/ParameterizedFunctionsTest.java
@@ -1,6 +1,6 @@
 package com.github.dakusui.crest.utils.ut;
 
-import com.github.dakusui.crest.utils.printable.Functions;
+import com.github.dakusui.crest.functions.printable.Functions;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.junit.Test;

--- a/src/test/java/com/github/dakusui/crest/utils/ut/ParameterizedPredicatesTest.java
+++ b/src/test/java/com/github/dakusui/crest/utils/ut/ParameterizedPredicatesTest.java
@@ -1,8 +1,8 @@
 package com.github.dakusui.crest.utils.ut;
 
 import com.github.dakusui.crest.utils.TestUtils;
-import com.github.dakusui.crest.utils.printable.Predicates;
-import com.github.dakusui.crest.utils.printable.Printable;
+import com.github.dakusui.crest.functions.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Printable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/com/github/dakusui/crest/utils/ut/PredicatesTest.java
+++ b/src/test/java/com/github/dakusui/crest/utils/ut/PredicatesTest.java
@@ -1,6 +1,6 @@
 package com.github.dakusui.crest.utils.ut;
 
-import com.github.dakusui.crest.utils.printable.Predicates;
+import com.github.dakusui.crest.functions.printable.Predicates;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
- Bump up the version to 4.1.x
- Make a string "NOT MET" printed for 'CompositeMatcher's (not, allOf, anyOf)
- Re-organize package structure.