### PR TITLE
Throw TestSkippedException instead of TestAbortedException

### DIFF
--- a/src/main/java/com/github/dakusui/crest/Crest.java
+++ b/src/main/java/com/github/dakusui/crest/Crest.java
@@ -9,6 +9,7 @@ import com.github.dakusui.thincrest_pcond.functions.Functions;
 import com.github.dakusui.thincrest_pcond.functions.Printable;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
+import org.opentest4j.TestSkippedException;
 
 import java.lang.reflect.Array;
 import java.util.*;
@@ -312,7 +313,7 @@ public enum Crest {
   public static <T> void assumeThat(String message, T value, Matcher<? super T> matcher) {
     Session.perform(
         message, value, matcher,
-        (msg, r, causes) -> new TestAbortedException(composeComparisonText(msg, r))
+        (msg, r, causes) -> new TestSkippedException(composeComparisonText(msg, r))
     );
   }
 

--- a/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
+++ b/src/test/java/com/github/dakusui/crest/ut/CrestTest.java
@@ -12,6 +12,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
+import org.opentest4j.TestSkippedException;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -726,12 +727,17 @@ public class CrestTest {
             "hello",
             asString().equalTo("HELLO").$()
         );
-      } catch (TestAbortedException e) {
+      } catch (TestSkippedException e) {
         // Wrap with IOException, which cannot happen in this test procedure to
-        // make sure intended exception (AssumptionViolatedException) is really
+        // make sure intended exception (TestSkippedException) is really
         // thrown.
         throw new IOException(e);
       }
+    }
+
+    @Test
+    public void testSkipped() {
+      throw new TestSkippedException();
     }
 
     @Test(expected = ExecutionFailure.class)


### PR DESCRIPTION
Issue #58: Throw TestSkippedException instead of TestAbortedException when a test is ignored.